### PR TITLE
Add lte option to date validator

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject clanhr/validators "0.5.2"
+(defproject clanhr/validators "0.6.0"
   :description "Utility model validators that integrate with validateur"
   :url "https://github.com/clanhr/validators"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[clj-time "0.9.0"]
+  :dependencies [[clj-time "0.12.0"]
                  [email-validator "0.1"]
                  [com.novemberain/validateur "2.4.2"]])

--- a/test/clanhr/validators/core_test.clj
+++ b/test/clanhr/validators/core_test.clj
@@ -1,6 +1,7 @@
 (ns clanhr.validators.core-test
-  (use clojure.test)
-  (require [clanhr.validators.core :as validate]
+  (:use clojure.test)
+  (:require [clanhr.validators.core :as validate]
+            [clj-time.core :as t]
            [clj-time.coerce :as c]))
 
 (deftest valid-date-test
@@ -15,7 +16,14 @@
     (is (first (validator {:date (c/from-string "2015-03-03T00:00:00.000Z")})))
     (is (first (validator {:date (c/to-sql-date "2015-03-03T00:00:00.000Z")})))
     (is (first (validator {:date (c/to-date "2015-03-03T00:00:00.000Z")})))
-    (is (not (first (validator {:date ""}))))))
+    (is (not (first (validator {:date ""}))))
+
+    (testing "only dates less than some date"
+      (let [validator (validate/date-validator :date {:lte (t/now)})]
+        (is (true? (first (validator {:date "2015-03-03T00:00:00.000Z"}))))
+        (is (true? (first (validator {:date (c/to-sql-date "2015-03-03T00:00:00.000Z")}))))
+        (is (true? (first (validator {:date (c/to-date "2015-03-03T00:00:00.000Z")}))))
+        (is (false? (first (validator {:date (c/to-date "2025-03-03T00:00:00.000Z")}))))))))
 
 (deftest email-validator-test
   (let [validator (validate/email-validator :email)]


### PR DESCRIPTION
If for example we want a date that it's no int the future, we can now
user `(date-validator :field {:lte (t/now)})`.
